### PR TITLE
Fix: Correct broken HTML tag in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                             <div class="product-content">
                                 <span class="product-category">Clothing</span>
                                 <a href="details.html">
-                                    <h3 class="product-title>Floral Beaded Tunic</h3>
+                                    <h3 class="product-title">Floral Beaded Tunic</h3>
                                 </a>
                                 <div class="product-rating">
                                     <i class="ri-star-fill"></i>


### PR DESCRIPTION
A missing closing quote in the class attribute of an h3 tag was causing rendering issues and preventing styles from being applied correctly. This commit adds the missing quote to fix the HTML syntax.